### PR TITLE
Changes to support WiFiSocketServerRTOS 8266 build

### DIFF
--- a/components/heap/Kconfig
+++ b/components/heap/Kconfig
@@ -13,4 +13,12 @@ menu "Heap memory"
         help
             Enables heap tracing API.
 
+    config HEAP_PRIO_8BIT_RAM
+        bool "Prioritize allocation of 8-bit access capable RAM"
+        default n
+        depends on !HEAP_DISABLE_IRAM
+        help
+            Set DRAM region ahead of IRAM region during initialization, so that allocations
+            can be made against it first.
+
 endmenu

--- a/components/lwip/port/esp8266/freertos/sys_arch.c
+++ b/components/lwip/port/esp8266/freertos/sys_arch.c
@@ -81,6 +81,7 @@ sys_mutex_lock(sys_mutex_t *pxMutex)
   BaseType_t ret = xSemaphoreTake(*pxMutex, portMAX_DELAY);
 
   LWIP_ASSERT("failed to take the mutex", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -94,6 +95,7 @@ sys_mutex_unlock(sys_mutex_t *pxMutex)
   BaseType_t ret = xSemaphoreGive(*pxMutex);
 
   LWIP_ASSERT("failed to give the mutex", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -133,6 +135,7 @@ sys_sem_new(sys_sem_t *sem, u8_t count)
   if (count == 1) {
       BaseType_t ret = xSemaphoreGive(*sem);
       LWIP_ASSERT("sys_sem_new: initial give failed", ret == pdTRUE);
+      (void)ret;
   }
 
   return ERR_OK;
@@ -150,6 +153,7 @@ sys_sem_signal(sys_sem_t *sem)
   /* queue full is OK, this is a signal only... */
   LWIP_ASSERT("sys_sem_signal: sane return value",
              (ret == pdTRUE) || (ret == errQUEUE_FULL));
+  (void)ret;
 }
 
 /*-----------------------------------------------------------------------------------*/
@@ -246,6 +250,7 @@ sys_mbox_post(sys_mbox_t *mbox, void *msg)
 {
   BaseType_t ret = xQueueSendToBack((*mbox)->os_mbox, &msg, portMAX_DELAY);
   LWIP_ASSERT("mbox post failed", ret == pdTRUE);
+  (void)ret;
 }
 
 /**
@@ -385,6 +390,8 @@ sys_mbox_free(sys_mbox_t *mbox)
   vQueueDelete((*mbox)->os_mbox);
   free(*mbox);
   *mbox = NULL;
+
+  (void)msgs_waiting;
 }
 
 /**

--- a/components/spi_flash/CMakeLists.txt
+++ b/components/spi_flash/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(srcs "src/partition"
+set(srcs "src/partition.c"
          "src/spi_flash_raw.c"
          "src/spi_flash.c")
 if(BOOTLOADER_BUILD)

--- a/components/tcpip_adapter/Kconfig
+++ b/components/tcpip_adapter/Kconfig
@@ -21,4 +21,11 @@ config TCPIP_ADAPTER_GLOBAL_DATA_LINK_IRAM
     help
         Link TCPIP adapter global data(.bss .data COMMON) from DRAM to IRAM.
 
+config TCPIP_ADAPTER_HOSTNAME_MAX_LENGTH
+    int "Max hostname length"
+    range 1 253
+    default 32
+    help
+        Maximum number of characters in the local hostname
+
 endmenu

--- a/components/tcpip_adapter/include/tcpip_adapter.h
+++ b/components/tcpip_adapter/include/tcpip_adapter.h
@@ -609,7 +609,6 @@ esp_interface_t tcpip_adapter_get_esp_if(void *dev);
  */
 esp_err_t tcpip_adapter_get_sta_list(wifi_sta_list_t *wifi_sta_list, tcpip_adapter_sta_list_t *tcpip_sta_list);
 
-#define TCPIP_HOSTNAME_MAX_SIZE    32
 /**
  * @brief  Set the hostname to the interface
  *

--- a/components/tcpip_adapter/tcpip_adapter_lwip.c
+++ b/components/tcpip_adapter/tcpip_adapter_lwip.c
@@ -46,6 +46,8 @@
 #include "FreeRTOS.h"
 #include "timers.h"
 
+#include "sdkconfig.h"
+
 struct tcpip_adapter_pbuf {
     struct pbuf_custom  pbuf;
 
@@ -1217,13 +1219,13 @@ esp_err_t tcpip_adapter_set_hostname(tcpip_adapter_if_t tcpip_if, const char *ho
 {
 #if LWIP_NETIF_HOSTNAME
     struct netif *p_netif;
-    static char hostinfo[TCPIP_ADAPTER_IF_MAX][TCPIP_HOSTNAME_MAX_SIZE + 1];
+    static char hostinfo[TCPIP_ADAPTER_IF_MAX][CONFIG_TCPIP_ADAPTER_HOSTNAME_MAX_LENGTH + 1];
 
     if (tcpip_if >= TCPIP_ADAPTER_IF_MAX || hostname == NULL) {
         return ESP_ERR_TCPIP_ADAPTER_INVALID_PARAMS;
     }
 
-    if (strlen(hostname) > TCPIP_HOSTNAME_MAX_SIZE) {
+    if (strlen(hostname) > CONFIG_TCPIP_ADAPTER_HOSTNAME_MAX_LENGTH) {
         return ESP_ERR_TCPIP_ADAPTER_INVALID_PARAMS;
     }
 


### PR DESCRIPTION
Changes for supporting WiFiSocketServerRTOS build on ESP8266. Use until the following upstream PR's are merged, included in the next release, and the WiFiSocketServerRTOS base is updated accordingly.

https://github.com/espressif/ESP8266_RTOS_SDK/pull/1212
https://github.com/espressif/ESP8266_RTOS_SDK/pull/1211
https://github.com/espressif/ESP8266_RTOS_SDK/pull/1210